### PR TITLE
ex5: fix flyer facts verification

### DIFF
--- a/starter/edinburgh_research/integrity.py
+++ b/starter/edinburgh_research/integrity.py
@@ -109,7 +109,7 @@ def fact_appears_in_log(fact: Any, log: list[ToolCallRecord] | None = None) -> b
             return any(_scan(v) for v in obj)
         return False
 
-    return any(_scan(r.output) or _scan(r.arguments) for r in records)
+    return any(_scan(r.output) for r in records)
 
 
 # ---------------------------------------------------------------------------
@@ -138,10 +138,13 @@ def verify_dataflow(flyer_content: str) -> IntegrityResult:
             ok=True, summary="no extractable facts in flyer (verified vacuously)"
         )
 
+    # Filter out generate_flyer own records
+    filtered_log = [r for r in _TOOL_CALL_LOG if r.tool_name != "generate_flyer"]
+
     verified: list[str] = []
     unverified: list[str] = []
     for fact in deduped:
-        if fact_appears_in_log(fact):
+        if fact_appears_in_log(fact, log=filtered_log):
             verified.append(fact)
         else:
             unverified.append(fact)

--- a/starter/edinburgh_research/run.py
+++ b/starter/edinburgh_research/run.py
@@ -71,7 +71,7 @@ def _build_fake_client() -> FakeLLMClient:
         name="calculate_cost",
         arguments={
             "venue_id": "haymarket_tap",
-            "party_size": 6,
+            "party_size": 5,
             "duration_hours": 3,
             "catering_tier": "bar_snacks",
         },
@@ -85,10 +85,10 @@ def _build_fake_client() -> FakeLLMClient:
                 "venue_address": "12 Dalry Rd, Edinburgh EH11 2BG",
                 "date": "2026-04-25",
                 "time": "19:30",
-                "party_size": 6,
+                "party_size": 5,
                 "condition": "cloudy",
                 "temperature_c": 12,
-                "total_gbp": 540,
+                "total_gbp": 497,
                 "deposit_required_gbp": 0,
             }
         },


### PR DESCRIPTION
Flyer facts verification was supposed to check that facts listed in the flyer were mentioned in other tool calls, but it erroneously included the generate_flyer tool call in the search. As a result, if this tool call was generated incorrectly by the model, the verification would still pass because the "facts" were present in at least one tool call— namely, generate_flyer itself.

Exclude the log of generate_flyer and search only in the outputs (not arguments) of other tools. Additionally, update the FakeLLMClient factory function to ensure calculate_cost and generate_flyer calls match, and make the total cost an integer to avoid rounding shenanigans.

Fixes: #14